### PR TITLE
Fix Passing 0 instead of _nftId at transferNFTFrom method

### DIFF
--- a/contracts/Marketplace.sol
+++ b/contracts/Marketplace.sol
@@ -123,7 +123,7 @@ contract Marketplace is IERC721Receiver {
         );
 
         // Lock NFT in Marketplace contract
-        require(nftCollection.transferNFTFrom(msg.sender, address(this), 0));
+        require(nftCollection.transferNFTFrom(msg.sender, address(this), _nftId));
 
         //Casting from address to address payable
         address payable currentBidOwner = payable(address(0));


### PR DESCRIPTION
When I did test,I couldn't create auctions at the same time for different NFTs,
`require(nftCollection.transferNFTFrom(msg.sender, address(this), 0));` at line 126 of  contracts/Marketplace.sol
is not working.